### PR TITLE
Correct the scope for ShortCircuitExpression

### DIFF
--- a/src/__tests__/async-no-await.ts
+++ b/src/__tests__/async-no-await.ts
@@ -98,5 +98,21 @@ ruleTester.run("async-no-await", rule, {
       `,
       errors: [{ messageId: "noAwaitBeforeReturnPromise" }, { messageId: "asyncCallNoAwait"}],
     },
+    {
+      code: `
+      async function b() {
+        return Promise.resolve();
+      };
+      async function d() {
+        return Promise.resolve();
+      };
+      const state = {
+        fetchData: async (ouId, treeId) => {
+          await d();
+          b();
+        }
+      }`,
+      errors: [{ messageId: "noAwaitBeforeReturnPromise" }, { messageId: "asyncCallNoAwait"}],
+    }
   ],
 });


### PR DESCRIPTION
Previous implementation will mark the whole function's `hasAwait` as true, resulting in unawaited CallExpression to be unchecked.
Add additional scopeInfo later for `ShortCircuitExpression` to correctly scope the escapable CallExpression